### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -5,14 +5,14 @@
 #######################################
 # Datatypes (KEYWORD1)
 #######################################
-BigNums2x2 KEYWORD1
+BigNums2x2	KEYWORD1
 
 #######################################
 # Methods and Functions (KEYWORD2)
 #######################################
 
-font KEYWORD2
-defaults KEYWORD2
+font	KEYWORD2
+defaults	KEYWORD2
 print	KEYWORD2
 
 #######################################


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords